### PR TITLE
W3cDatetime.parse: return DateTime, don't quash errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
+  - 2.4.1
   - 2.0.0
   - 1.9.3
-  - 1.9.2
-  - jruby-19mode # JRuby in 1.9 mode
-  - rbx-19mode

--- a/lib/date_time.rb
+++ b/lib/date_time.rb
@@ -1,0 +1,5 @@
+class DateTime
+  def to_w3c_datetime
+    strftime '%FT%T.%L%:z'
+  end
+end

--- a/lib/time.rb
+++ b/lib/time.rb
@@ -1,5 +1,0 @@
-class Time
-  def to_w3c_datetime
-	strftime '%Y-%m-%dT%H:%M:%S' + strftime('%z').insert(3, ':')
-  end
-end

--- a/lib/w3c_datetime.rb
+++ b/lib/w3c_datetime.rb
@@ -1,2 +1,2 @@
 require File.dirname(__FILE__) + '/w3c_datetime/w3c_datetime'
-require File.dirname(__FILE__) + '/time'
+require File.dirname(__FILE__) + '/date_time'

--- a/lib/w3c_datetime/w3c_datetime.rb
+++ b/lib/w3c_datetime/w3c_datetime.rb
@@ -39,6 +39,10 @@ class W3cDatetime
   end
 
   def self.get_timezone(timezone)
+    if timezone.to_i > 14
+      raise ArgumentError, "#{timezone} is not a valid offset"
+    end
+
     case timezone
     when 'Z', '', nil
       '+00:00'

--- a/lib/w3c_datetime/w3c_datetime.rb
+++ b/lib/w3c_datetime/w3c_datetime.rb
@@ -19,7 +19,7 @@ class W3cDatetime
   #     http://www.w3.org/TR/NOTE-datetime format
   # @return [DateTime]
   def self.parse(date_str)
-    date_regexp = /^(?<year>\d{4})(?:-(?<month>\d{2})(?:-(?<day>\d{2})(?:T(?<hour>\d{2}):(?<minute>\d{2}):?(?<second>\d{2})?\.?(?<milisecond>\d{1,2})?(?:(?<timezone>.+)|Z)?)?)?)?$/
+    date_regexp = /^(?<year>-?\d{4})(?:-(?<month>\d{2})(?:-(?<day>\d{2})(?:T(?<hour>\d{2}):(?<minute>\d{2}):?(?<second>\d{2})?\.?(?<milisecond>\d{1,3})?(?:(?<timezone>.+)|Z)?)?)?)?$/
     parsed = date_regexp.match(date_str)
 
     if parsed.nil?

--- a/lib/w3c_datetime/w3c_datetime.rb
+++ b/lib/w3c_datetime/w3c_datetime.rb
@@ -19,10 +19,21 @@ class W3cDatetime
   def self.parse(date_str)
     date_regexp = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:T(?<hour>\d{2}):(?<minute>\d{2}):?(?<second>\d{2})?\.?(?<milisecond>\d{1,2})?(?:(?<timezone>.+)|Z)?)?$/
     parsed = date_regexp.match(date_str)
-    begin
-      Time.new(parsed[:year].to_i, parsed[:month].to_i, parsed[:day].to_i, parsed[:hour].to_i, parsed[:minute].to_i, parsed[:second].to_i, get_timezone(parsed[:timezone])) unless parsed.nil?
-    rescue ArgumentError, TypeError
+
+    if parsed.nil?
+      raise ArgumentError,
+            "#{date_str} is not W3C-valid (http://www.w3.org/TR/NOTE-datetime)"
     end
+
+    Time.new(
+      parsed[:year].to_i,
+      parsed[:month].to_i,
+      parsed[:day].to_i,
+      parsed[:hour].to_i,
+      parsed[:minute].to_i,
+      parsed[:second].to_i,
+      get_timezone(parsed[:timezone])
+    )
   end
 
   class << self

--- a/lib/w3c_datetime/w3c_datetime.rb
+++ b/lib/w3c_datetime/w3c_datetime.rb
@@ -19,12 +19,21 @@ class W3cDatetime
   #     http://www.w3.org/TR/NOTE-datetime format
   # @return [DateTime]
   def self.parse(date_str)
-    date_regexp = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:T(?<hour>\d{2}):(?<minute>\d{2}):?(?<second>\d{2})?\.?(?<milisecond>\d{1,2})?(?:(?<timezone>.+)|Z)?)?$/
+    date_regexp = /^(?<year>\d{4})(?:-(?<month>\d{2})(?:-(?<day>\d{2})(?:T(?<hour>\d{2}):(?<minute>\d{2}):?(?<second>\d{2})?\.?(?<milisecond>\d{1,2})?(?:(?<timezone>.+)|Z)?)?)?)?$/
     parsed = date_regexp.match(date_str)
 
     if parsed.nil?
       raise ArgumentError,
             "#{date_str} is not W3C-valid (http://www.w3.org/TR/NOTE-datetime)"
+    end
+
+    # YYYY and YYYY-MM are valid W3C dates, but since nil.to_i is 0 we
+    # have to give these two special handling or else below we'll try
+    # to do DateTime.new(2017, 0, 0), which is not valid.
+    return DateTime.new(parsed[:year].to_i) if parsed[:month].nil?
+
+    if parsed[:day].nil?
+      return DateTime.new(parsed[:year].to_i, parsed[:month].to_i)
     end
 
     DateTime.new(

--- a/lib/w3c_datetime/w3c_datetime.rb
+++ b/lib/w3c_datetime/w3c_datetime.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 # Handle W3 Date and Time formats
 #
 # Handle W3 Date and Time formats as specified in http://www.w3.org/TR/NOTE-datetime
@@ -11,11 +13,11 @@
 #
 # @author Michal Pawlowski <misza222@gmail.com>
 class W3cDatetime
-
   # Parse date string in http://www.w3.org/TR/NOTE-datetime format
   #
-  # @param [String] date_str date represented as string in http://www.w3.org/TR/NOTE-datetime format
-  # @return [Time] Time object
+  # @param [String] date_str date represented as string in
+  #     http://www.w3.org/TR/NOTE-datetime format
+  # @return [DateTime]
   def self.parse(date_str)
     date_regexp = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})(?:T(?<hour>\d{2}):(?<minute>\d{2}):?(?<second>\d{2})?\.?(?<milisecond>\d{1,2})?(?:(?<timezone>.+)|Z)?)?$/
     parsed = date_regexp.match(date_str)
@@ -25,7 +27,7 @@ class W3cDatetime
             "#{date_str} is not W3C-valid (http://www.w3.org/TR/NOTE-datetime)"
     end
 
-    Time.new(
+    DateTime.new(
       parsed[:year].to_i,
       parsed[:month].to_i,
       parsed[:day].to_i,
@@ -36,15 +38,11 @@ class W3cDatetime
     )
   end
 
-  class << self
-    private
-    def get_timezone(timezone)
-      if timezone == 'Z'
-        timezone = '+00:00'
-      elsif timezone == ''
-        timezone = nil
-      end
-
+  def self.get_timezone(timezone)
+    case timezone
+    when 'Z', '', nil
+      '+00:00'
+    else
       timezone
     end
   end

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -1,12 +1,12 @@
 require 'minitest/autorun'
 require 'w3c_datetime'
 
-describe Time do
+describe DateTime do
   describe '#to_w3c_datetime' do
-  	it 'should return string representing time in W3C date time format' do
-  	  t = Time.new
+    it 'should return string representing time in W3C date time format' do
+      t = DateTime.new
 
-  	  t.must_be_within_delta W3cDatetime::parse(t.to_w3c_datetime), 1
-  	end
+      t.must_be_within_delta W3cDatetime.parse(t.to_w3c_datetime), 1
+    end
   end
 end

--- a/test/test_time.rb
+++ b/test/test_time.rb
@@ -1,4 +1,3 @@
-require 'minitest/spec'
 require 'minitest/autorun'
 require 'w3c_datetime'
 
@@ -6,8 +5,8 @@ describe Time do
   describe '#to_w3c_datetime' do
   	it 'should return string representing time in W3C date time format' do
   	  t = Time.new
-  	  
+
   	  t.must_be_within_delta W3cDatetime::parse(t.to_w3c_datetime), 1
   	end
-  end	
+  end
 end

--- a/test/test_w3c_datetime.rb
+++ b/test/test_w3c_datetime.rb
@@ -2,56 +2,189 @@ require 'minitest/autorun'
 require 'w3c_datetime'
 
 describe W3cDatetime do
-  it "does not parse rubbish" do
-    W3cDatetime::parse('ala ma kota').must_be_nil
-    W3cDatetime::parse('2012-03-20 ala ma kota').must_be_nil
-    W3cDatetime::parse('sth stupid2012-03-20').must_be_nil
-    W3cDatetime::parse('2012-03-20T99:00:99').must_be_nil
-    W3cDatetime::parse('2012-13-20').must_be_nil
-    W3cDatetime::parse('2012-12-20T10:10+25:00').must_be_nil
+  it 'does not parse rubbish and invalid dates' do
+    assert_raises ArgumentError do
+      W3cDatetime.parse('ala ma kota')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2012-03-20 ala ma kota')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('sth stupid2012-03-20')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2012-03-20T99:00:99')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2012-13-20')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2012-12-20T10:10+25:00')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('194-02-28')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('194')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940-2')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940-2-28')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940-02-2')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940-2-2')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2/28/1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28/2/1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2-28-1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28-2-1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2-2-1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('February 28, 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('Feb 28, 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28 February 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28 Feb 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('Feb. 28, 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28 Feb. 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('February 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('Feb. 1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940 February')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940 Feb.')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('1940-02-30')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('02/28/1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28/02/1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('2/28/40')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28/2/40')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('02-28-1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('28-02-1940')
+    end
+
+    assert_raises ArgumentError do
+      W3cDatetime.parse('02-02-1940')
+    end
   end
 
-  it "returns Time object" do
-    W3cDatetime::parse('2013-02-10').must_be_instance_of Time
+  it 'returns DateTime object' do
+    W3cDatetime.parse('2013-02-10').must_be_instance_of DateTime
   end
 
-  it "parses date" do
-    W3cDatetime::parse('2013-02-10').must_equal Time.new(2013,02,10)
+  it 'parses date' do
+    W3cDatetime.parse('2013-02-10').must_equal DateTime.new(2013, 0o2, 10)
   end
 
-  it "parses date with hour and minute" do
-    W3cDatetime::parse('2013-02-10T10:10').must_equal Time.new(2013,02,10,10,10)
+  it 'parses date with hour and minute' do
+    W3cDatetime.parse('2013-02-10T10:10').must_equal DateTime.new(2013, 0o2, 10, 10, 10)
   end
 
-  it "parses date with time" do
-    W3cDatetime::parse('2013-02-10T10:10:20').must_equal Time.new(2013,02,10,10,10,20)
+  it 'parses date with time' do
+    W3cDatetime.parse('2013-02-10T10:10:20').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 20)
   end
 
-  it "parses date with time and timezone" do
-    W3cDatetime::parse('2013-02-10T10:10:20+10:00').must_equal Time.new(2013,02,10,10,10,20, '+10:00')
+  it 'parses date with time and timezone' do
+    W3cDatetime.parse('2013-02-10T10:10:20+10:00').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 20, '+10:00')
   end
 
-  it "parses date with time and Zulu offset" do
-    W3cDatetime::parse('2013-02-10T10:10:20Z').must_equal Time.new(2013,02,10,10,10,20, '+00:00')
+  it 'parses date with time and Zulu offset' do
+    W3cDatetime.parse('2013-02-10T10:10:20Z').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 20, '+00:00')
   end
 
-  it "parses date with time and miliseconds" do
-    W3cDatetime::parse('2013-02-10T10:10:20.30').must_equal Time.new(2013,02,10,10,10,20)
+  it 'parses date with time and miliseconds' do
+    W3cDatetime.parse('2013-02-10T10:10:20.30').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 20)
   end
 
-  it "parses date with hour and minute and offset" do
-    W3cDatetime::parse('2013-02-10T10:10+10:30').must_equal Time.new(2013,02,10,10,10,nil,'+10:30')
+  it 'parses date with hour and minute and offset' do
+    W3cDatetime.parse('2013-02-10T10:10+10:30').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 0, '+10:30')
   end
 
-  it "parses date with time and offset" do
-    W3cDatetime::parse('2013-02-10T10:10:10+10:30').must_equal Time.new(2013,02,10,10,10,10,'+10:30')
+  it 'parses date with time and offset' do
+    W3cDatetime.parse('2013-02-10T10:10:10+10:30').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 10, '+10:30')
   end
 
-  it "parses date with time and miliseconds and offset" do
-    W3cDatetime::parse('2013-02-10T10:10:10.30+10:30').must_equal Time.new(2013,02,10,10,10,10,'+10:30')
+  it 'parses date with time and miliseconds and offset' do
+    W3cDatetime.parse('2013-02-10T10:10:10.30+10:30').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 10, '+10:30')
   end
 
-  it "parses date with time and miliseconds and Zulu offset" do
-    W3cDatetime::parse('2013-02-10T10:10:10.30Z').must_equal Time.new(2013,02,10,10,10,10,'+00:00')
+  it 'parses date with time and miliseconds and Zulu offset' do
+    W3cDatetime.parse('2013-02-10T10:10:10.30Z').must_equal DateTime.new(2013, 0o2, 10, 10, 10, 10, '+00:00')
   end
 end

--- a/test/test_w3c_datetime.rb
+++ b/test/test_w3c_datetime.rb
@@ -148,6 +148,14 @@ describe W3cDatetime do
     W3cDatetime.parse('2013-02-10').must_be_instance_of DateTime
   end
 
+  it 'parses year' do
+    W3cDatetime.parse('2013').must_equal DateTime.new(2013)
+  end
+
+  it 'parses year and month' do
+    W3cDatetime.parse('2013-02').must_equal DateTime.new(2013, 0o2)
+  end
+
   it 'parses date' do
     W3cDatetime.parse('2013-02-10').must_equal DateTime.new(2013, 0o2, 10)
   end

--- a/test/test_w3c_datetime.rb
+++ b/test/test_w3c_datetime.rb
@@ -1,4 +1,3 @@
-require 'minitest/spec'
 require 'minitest/autorun'
 require 'w3c_datetime'
 

--- a/w3c_datetime.gemspec
+++ b/w3c_datetime.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>=1.9.2'
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
The errors can be useful to downstream applications.

Also:
* return a `DateTime` instead of `Time` to catch things like February 30.
* do some basic checking of the timezone offset.
* add more bad dates to the tests.